### PR TITLE
Allow defaults overrides using environment variables

### DIFF
--- a/lib/HostsManager.ts
+++ b/lib/HostsManager.ts
@@ -8,8 +8,9 @@ export interface Host {
   path: string
 }
 
-const DEFAULT_HOST = 'localhost:27017';
-const DATABASE_FILE = path.join(os.homedir(), '.mongoku.db');
+const DEFAULT_HOST = process.env.MONGOKU_DEFAULT_HOST || 'localhost:27017';
+const DATABASE_FILE = process.env.MONGOKU_DATABASE_FILE || path.join(os.homedir(), '.mongoku.db');
+
 
 export class HostsManager {
   private _db: Nedb;

--- a/lib/HostsManager.ts
+++ b/lib/HostsManager.ts
@@ -8,7 +8,7 @@ export interface Host {
   path: string
 }
 
-const DEFAULT_HOST = process.env.MONGOKU_DEFAULT_HOST || 'localhost:27017';
+const DEFAULT_HOSTS = process.env.MONGOKU_DEFAULT_HOST ? process.env.MONGOKU_DEFAULT_HOST.split(';') : ['localhost:27017'];
 const DATABASE_FILE = process.env.MONGOKU_DATABASE_FILE || path.join(os.homedir(), '.mongoku.db');
 
 
@@ -35,10 +35,12 @@ export class HostsManager {
     await load();
 
     if (first) {
-      const insert: any = this.promise(this._db.insert);
-      await insert({
-        path: DEFAULT_HOST
-      });
+      await Promise.all(DEFAULT_HOSTS.map(async hostname => {
+        const insert: any = this.promise(this._db.insert);
+        return await insert({
+          path: hostname
+        });
+      }));
     }
   }
 

--- a/server.ts
+++ b/server.ts
@@ -8,6 +8,8 @@ import factory from './lib/Factory';
 import { api } from './routes/api';
 
 const setupServer = () => {
+  const SERVER_PORT = process.env.MONGOKU_SERVER_PORT || 3100;
+
   app.get('/', (req, res, next) => {
     res.sendFile("app/index.html", { root: __dirname }, (err) => {
       if (err) {
@@ -44,7 +46,7 @@ const setupServer = () => {
     });
   })
 
-  app.listen(3100, () => console.log(`[Mongoku] listening on port 3100`));
+  app.listen(SERVER_PORT, () => console.log(`[Mongoku] listening on port `+SERVER_PORT));
 }
 
 export const start = async () => {


### PR DESCRIPTION
Overriding defaults: **server port**, **database location**, **default mongo host** can be useful in container environments cf. #14 , #12

It doesn't affect default behavior. To test:

`tsc && MONGOKU_SERVER_PORT=8000 MONGOKU_DEFAULT_HOST="127.0.0.1:27017;127.0.0.1:27117" MONGOKU_DATABASE_FILE='/tmp/mongoku.db' node dist/server.js
`