### PR TITLE
Add timeout for find queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,7 @@ MONGOKU_DATABASE_FILE="/tmp/mongoku.db"
 
 # Timeout before falling back to estimated documents count in ms (Default = 5000)
 MONGOKU_COUNT_TIMEOUT=1000
+
+# Timeout before aborting find query in ms (Default = 300000)
+MONGOKU_QUERY_TIMEOUT=5000
 ```

--- a/lib/Collection.ts
+++ b/lib/Collection.ts
@@ -19,6 +19,7 @@ export interface CollectionJSON {
 export class Collection {
   private _collection: MongoDb.Collection;
   private countTimeout = parseInt(process.env.MONGOKU_COUNT_TIMEOUT!, 10) || 5000;
+  private queryTimeout = parseInt(process.env.MONGOKU_QUERY_TIMEOUT!, 10) || 300000;
 
   get name() {
     return this._collection.collectionName;
@@ -44,6 +45,7 @@ export class Collection {
       .map((obj) => {
         return JsonEncoder.encode(obj);
       })
+      .maxTimeMS(this.queryTimeout)
       .toArray();
   }
 


### PR DESCRIPTION
Browser usually drops connection after 5 minutes as timeout request, but find query continues to execute and create cpu load. This behaviour can be reproduced with regexp query on big dbs (millions of documents).