### PR TITLE
Skip per-collection stats on servers and databases pages

### DIFF
--- a/src/routes/servers/+page.server.ts
+++ b/src/routes/servers/+page.server.ts
@@ -1,6 +1,5 @@
 import { logger } from "$lib/server/logger";
 import { getMongo } from "$lib/server/mongo";
-import type { DatabaseStats } from "$lib/types";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async () => {
@@ -14,26 +13,11 @@ export const load: PageServerLoad = async () => {
 				const adminDb = client.db("test").admin();
 				const results = await adminDb.listDatabases();
 				const filteredDatabases = mongo.filterDatabases(results.databases);
-				const collectionsCount = await Promise.all(
-					filteredDatabases.map(async (d) => {
-						const db = client.db(d.name);
-						const dbStats: Pick<DatabaseStats, "collections"> = await (db.stats() as Promise<DatabaseStats>).catch(
-							() => {
-								logger.error(`Error getting stats for database ${d.name} on server ${name}`);
-								return {
-									collections: 0,
-								};
-							},
-						);
-						return dbStats.collections;
-					}),
-				);
 
 				return {
-					databases: filteredDatabases.map((d, index) => ({
+					databases: filteredDatabases.map((d) => ({
 						name: d.name,
 						size: d.sizeOnDisk ?? 0,
-						collections: collectionsCount[index],
 					})),
 					size: results.totalSize ?? 0,
 				};

--- a/src/routes/servers/+page.svelte
+++ b/src/routes/servers/+page.svelte
@@ -151,12 +151,10 @@
 									<TooltipTable
 										columns={[
 											{ header: "Database", key: "name" },
-											{ header: "Collections", key: "collections" },
 											{ header: "Size", key: "size" },
 										]}
 										rows={details.databases.map((db) => ({
 											name: db.name,
-											collections: db.collections,
 											size: formatBytes(db.size),
 										}))}
 									>

--- a/src/routes/servers/[server]/databases/+page.server.ts
+++ b/src/routes/servers/[server]/databases/+page.server.ts
@@ -1,6 +1,6 @@
 import { logger } from "$lib/server/logger";
-import { getCollectionJson, getMongo } from "$lib/server/mongo";
-import type { CollectionJSON, DatabaseStats } from "$lib/types";
+import { getMongo } from "$lib/server/mongo";
+import type { DatabaseStats } from "$lib/types";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ params }) => {
@@ -32,12 +32,6 @@ export const load: PageServerLoad = async ({ params }) => {
 					};
 				});
 
-			const collectionsJson = db
-				.listCollections()
-				.toArray()
-				.then((c) => c.sort((a, b) => a.name.localeCompare(b.name)))
-				.then((c) => Promise.all(c.map((c) => getCollectionJson(db.collection(c.name), c.type))));
-
 			return {
 				name: db.databaseName,
 				size: d.sizeOnDisk ?? 0,
@@ -47,7 +41,6 @@ export const load: PageServerLoad = async ({ params }) => {
 				totalIndexSize: dbStats.indexSize,
 				empty: d.empty ?? true,
 				nCollections: dbStats.collections,
-				collections: collectionsJson.catch(() => [] as CollectionJSON[]),
 			};
 		}),
 	);

--- a/src/routes/servers/[server]/databases/+page.svelte
+++ b/src/routes/servers/[server]/databases/+page.svelte
@@ -76,22 +76,7 @@
 							</a>
 						</td>
 						<td>
-							{#await database.collections}
-								{database.nCollections}
-							{:then collections}
-								<TooltipTable
-									columns={[
-										{ header: "Collection", key: "name", align: "left" },
-										{ header: "Size", key: "size", align: "right" },
-									]}
-									rows={collections.map((collection) => ({
-										name: collection.name,
-										size: formatBytes(collection.size),
-									}))}
-								>
-									{database.nCollections}
-								</TooltipTable>
-							{/await}
+							{database.nCollections}
 						</td>
 						<td>
 							{#if database.size !== undefined}


### PR DESCRIPTION
- This removes calling $collStats and list indexes for every collection in every database on every page load. This increases performance dramatically.
- collection details will load only when database is opened

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path performance optimization with simpler UI on list pages; no auth or write-path changes.
> 
> **Overview**
> Stops eagerly loading **per-collection** MongoDB stats on the servers list and per-database list views so page loads avoid `db.stats()` per database (for collection counts) and `getCollectionJson` / collection listing on the databases page.
> 
> The **servers** overview no longer fetches collection counts per database; the database tooltip shows only name and size. The **databases** table still shows `nCollections` from `db.stats()` but drops the hover table of every collection’s size. Per-collection detail remains on the **collections** route when a database is opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d963ee6c1a6e79d4d43bc10ae47d416dff9baa28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->