### PR TITLE
Implement MongoDB user and role management interface

### DIFF
--- a/src/api/servers.remote.ts
+++ b/src/api/servers.remote.ts
@@ -1094,10 +1094,12 @@ export const auditSchema = command(
 // ────────────────────────────────────────────────────────────────────────────
 // User management
 // ────────────────────────────────────────────────────────────────────────────
-// The MongoDB `usersInfo` / `rolesInfo` / `createUser` / `dropUser` /
-// `grantRolesToUser` / `revokeRolesFromUser` / `updateUser` commands only ever
-// run against the **admin** database. Each command below resolves the server's
-// MongoClient and issues the command against `client.db("admin")`.
+// MongoDB identifies a user by (user, db). `usersInfo: 1` against the admin
+// database lists every user on the cluster (regardless of the db they were
+// created on), and each returned document carries its own `db` field.
+// The mutating commands (dropUser / grantRolesToUser / revokeRolesFromUser /
+// updateUser) must run against the database the user lives on, so every
+// command below accepts a `db` argument and issues `client.db(db).command(...)`.
 
 /**
  * Role reference as accepted by MongoDB role-management commands.
@@ -1111,19 +1113,41 @@ const roleRefSchema = z.union([
 	}),
 ]);
 
-// List all users on the admin database, with their roles and privileges.
+// List all users on the cluster, with their resolved privileges.
 export const listUsers = query(z.object({ server: z.string() }), async ({ server }) => {
 	logger.log("listUsers called with payload:", { server });
 	const mongo = await getMongo();
 	const client = mongo.getClient(server);
 	const admin = client.db("admin");
 	try {
-		// usersInfo: 1 returns all users in the current db (admin).
-		// showPrivileges: true adds a `inheritedPrivileges` array per user
-		// and resolves the privilege docs for each inherited role.
-		const result = await admin.command({ usersInfo: 1, showPrivileges: true });
+		// `usersInfo: 1` lists all users in the current db (admin) — which on a
+		// cluster means every user. `showPrivileges: true` is NOT allowed with a
+		// non-exact (all-users) query unless the caller has grantRole privileges,
+		// so we list first, then fetch each user's resolved privileges via an
+		// exact-match query (which MongoDB always permits).
+		const result = await admin.command({ usersInfo: 1 });
+		const users = (result.users ?? []) as Array<{ user: string; db: string }>;
+
+		const usersWithPrivs = await Promise.all(
+			users.map(async (u) => {
+				try {
+					const info = await admin.command({
+						usersInfo: { user: u.user, db: u.db },
+						showPrivileges: true,
+					});
+					const detail = (info.users ?? [])[0] ?? {};
+					return { ...u, ...detail };
+				} catch (err) {
+					// Privilege resolution failed for this user — keep the base record
+					logger.error(`Error getting privileges for user ${u.user}:`, err);
+					return u;
+				}
+			}),
+		);
+
 		return {
-			data: JsonEncoder.encode(result.users ?? []),
+			// JSON round-trip strips MongoDB special types for safe transport
+			data: JSON.parse(JSON.stringify(JsonEncoder.encode(usersWithPrivs))),
 			error: null as string | null,
 		};
 	} catch (err) {
@@ -1147,7 +1171,7 @@ export const listRoles = query(z.object({ server: z.string() }), async ({ server
 		// showPrivileges: true resolves the full privilege list for each role.
 		const result = await admin.command({ rolesInfo: 1, showBuiltinRoles: true, showPrivileges: true });
 		return {
-			data: JsonEncoder.encode(result.roles ?? []),
+			data: JSON.parse(JSON.stringify(JsonEncoder.encode(result.roles ?? []))),
 			error: null as string | null,
 		};
 	} catch (err) {
@@ -1159,24 +1183,26 @@ export const listRoles = query(z.object({ server: z.string() }), async ({ server
 	}
 });
 
-// Create a new user on the admin database.
+// Create a new user. The user is created on the `db` it should live on
+// (defaults to "admin" when omitted).
 export const createUser = command(
 	z.object({
 		server: z.string(),
 		username: z.string(),
 		password: z.string(),
+		db: z.string().default("admin"),
 		roles: z.array(roleRefSchema).default([]),
 	}),
-	async ({ server, username, password, roles }) => {
-		logger.log("createUser called with payload:", { server, username, roles });
+	async ({ server, username, password, db, roles }) => {
+		logger.log("createUser called with payload:", { server, username, db, roles });
 		checkReadOnly();
 		const mongo = await getMongo();
 		const client = mongo.getClient(server);
-		const admin = client.db("admin");
+		const targetDb = client.db(db);
 		try {
 			// Decode role refs so {$type:...} markers (not expected here, but safe) are handled.
 			const decodedRoles = JsonEncoder.decode(roles);
-			await admin.command({
+			await targetDb.command({
 				createUser: username,
 				pwd: password,
 				roles: decodedRoles,
@@ -1192,20 +1218,21 @@ export const createUser = command(
 	},
 );
 
-// Drop an existing user from the admin database.
+// Drop an existing user. Runs against the db the user lives on.
 export const dropUser = command(
 	z.object({
 		server: z.string(),
 		username: z.string(),
+		db: z.string().default("admin"),
 	}),
-	async ({ server, username }) => {
-		logger.log("dropUser called with payload:", { server, username });
+	async ({ server, username, db }) => {
+		logger.log("dropUser called with payload:", { server, username, db });
 		checkReadOnly();
 		const mongo = await getMongo();
 		const client = mongo.getClient(server);
-		const admin = client.db("admin");
+		const targetDb = client.db(db);
 		try {
-			await admin.command({ dropUser: username });
+			await targetDb.command({ dropUser: username });
 			return { ok: true, error: null as string | null };
 		} catch (err) {
 			logger.error("Error dropping user:", err);
@@ -1217,22 +1244,23 @@ export const dropUser = command(
 	},
 );
 
-// Grant roles to an existing user.
+// Grant roles to an existing user. Runs against the db the user lives on.
 export const grantRolesToUser = command(
 	z.object({
 		server: z.string(),
 		username: z.string(),
+		db: z.string().default("admin"),
 		roles: z.array(roleRefSchema),
 	}),
-	async ({ server, username, roles }) => {
-		logger.log("grantRolesToUser called with payload:", { server, username, roles });
+	async ({ server, username, db, roles }) => {
+		logger.log("grantRolesToUser called with payload:", { server, username, db, roles });
 		checkReadOnly();
 		const mongo = await getMongo();
 		const client = mongo.getClient(server);
-		const admin = client.db("admin");
+		const targetDb = client.db(db);
 		try {
 			const decodedRoles = JsonEncoder.decode(roles);
-			await admin.command({
+			await targetDb.command({
 				grantRolesToUser: username,
 				roles: decodedRoles,
 			});
@@ -1247,22 +1275,23 @@ export const grantRolesToUser = command(
 	},
 );
 
-// Revoke roles from an existing user.
+// Revoke roles from an existing user. Runs against the db the user lives on.
 export const revokeRolesFromUser = command(
 	z.object({
 		server: z.string(),
 		username: z.string(),
+		db: z.string().default("admin"),
 		roles: z.array(roleRefSchema),
 	}),
-	async ({ server, username, roles }) => {
-		logger.log("revokeRolesFromUser called with payload:", { server, username, roles });
+	async ({ server, username, db, roles }) => {
+		logger.log("revokeRolesFromUser called with payload:", { server, username, db, roles });
 		checkReadOnly();
 		const mongo = await getMongo();
 		const client = mongo.getClient(server);
-		const admin = client.db("admin");
+		const targetDb = client.db(db);
 		try {
 			const decodedRoles = JsonEncoder.decode(roles);
-			await admin.command({
+			await targetDb.command({
 				revokeRolesFromUser: username,
 				roles: decodedRoles,
 			});
@@ -1277,21 +1306,22 @@ export const revokeRolesFromUser = command(
 	},
 );
 
-// Reset a user's password.
+// Reset a user's password. Runs against the db the user lives on.
 export const updateUserPassword = command(
 	z.object({
 		server: z.string(),
 		username: z.string(),
+		db: z.string().default("admin"),
 		password: z.string(),
 	}),
-	async ({ server, username, password }) => {
-		logger.log("updateUserPassword called with payload:", { server, username });
+	async ({ server, username, db, password }) => {
+		logger.log("updateUserPassword called with payload:", { server, username, db });
 		checkReadOnly();
 		const mongo = await getMongo();
 		const client = mongo.getClient(server);
-		const admin = client.db("admin");
+		const targetDb = client.db(db);
 		try {
-			await admin.command({
+			await targetDb.command({
 				updateUser: username,
 				pwd: password,
 			});

--- a/src/api/servers.remote.ts
+++ b/src/api/servers.remote.ts
@@ -1090,3 +1090,218 @@ export const auditSchema = command(
 		}
 	},
 );
+
+// ────────────────────────────────────────────────────────────────────────────
+// User management
+// ────────────────────────────────────────────────────────────────────────────
+// The MongoDB `usersInfo` / `rolesInfo` / `createUser` / `dropUser` /
+// `grantRolesToUser` / `revokeRolesFromUser` / `updateUser` commands only ever
+// run against the **admin** database. Each command below resolves the server's
+// MongoClient and issues the command against `client.db("admin")`.
+
+/**
+ * Role reference as accepted by MongoDB role-management commands.
+ * A bare string means "role on the admin db"; an object can target another db.
+ */
+const roleRefSchema = z.union([
+	z.string(),
+	z.object({
+		role: z.string(),
+		db: z.string(),
+	}),
+]);
+
+// List all users on the admin database, with their roles and privileges.
+export const listUsers = query(z.object({ server: z.string() }), async ({ server }) => {
+	logger.log("listUsers called with payload:", { server });
+	const mongo = await getMongo();
+	const client = mongo.getClient(server);
+	const admin = client.db("admin");
+	try {
+		// usersInfo: 1 returns all users in the current db (admin).
+		// showPrivileges: true adds a `inheritedPrivileges` array per user
+		// and resolves the privilege docs for each inherited role.
+		const result = await admin.command({ usersInfo: 1, showPrivileges: true });
+		return {
+			data: JsonEncoder.encode(result.users ?? []),
+			error: null as string | null,
+		};
+	} catch (err) {
+		logger.error("Error listing users:", err);
+		return {
+			data: [],
+			error: `Failed to list users: ${err instanceof Error ? err.message : String(err)}`,
+		};
+	}
+});
+
+// List all roles on the admin database, including built-in roles.
+export const listRoles = query(z.object({ server: z.string() }), async ({ server }) => {
+	logger.log("listRoles called with payload:", { server });
+	const mongo = await getMongo();
+	const client = mongo.getClient(server);
+	const admin = client.db("admin");
+	try {
+		// rolesInfo: 1 returns all user-defined roles in the current db.
+		// showBuiltinRoles: true also returns the built-in roles (read, readWrite, …).
+		// showPrivileges: true resolves the full privilege list for each role.
+		const result = await admin.command({ rolesInfo: 1, showBuiltinRoles: true, showPrivileges: true });
+		return {
+			data: JsonEncoder.encode(result.roles ?? []),
+			error: null as string | null,
+		};
+	} catch (err) {
+		logger.error("Error listing roles:", err);
+		return {
+			data: [],
+			error: `Failed to list roles: ${err instanceof Error ? err.message : String(err)}`,
+		};
+	}
+});
+
+// Create a new user on the admin database.
+export const createUser = command(
+	z.object({
+		server: z.string(),
+		username: z.string(),
+		password: z.string(),
+		roles: z.array(roleRefSchema).default([]),
+	}),
+	async ({ server, username, password, roles }) => {
+		logger.log("createUser called with payload:", { server, username, roles });
+		checkReadOnly();
+		const mongo = await getMongo();
+		const client = mongo.getClient(server);
+		const admin = client.db("admin");
+		try {
+			// Decode role refs so {$type:...} markers (not expected here, but safe) are handled.
+			const decodedRoles = JsonEncoder.decode(roles);
+			await admin.command({
+				createUser: username,
+				pwd: password,
+				roles: decodedRoles,
+			});
+			return { ok: true, error: null as string | null };
+		} catch (err) {
+			logger.error("Error creating user:", err);
+			return {
+				ok: false,
+				error: `Failed to create user: ${err instanceof Error ? err.message : String(err)}`,
+			};
+		}
+	},
+);
+
+// Drop an existing user from the admin database.
+export const dropUser = command(
+	z.object({
+		server: z.string(),
+		username: z.string(),
+	}),
+	async ({ server, username }) => {
+		logger.log("dropUser called with payload:", { server, username });
+		checkReadOnly();
+		const mongo = await getMongo();
+		const client = mongo.getClient(server);
+		const admin = client.db("admin");
+		try {
+			await admin.command({ dropUser: username });
+			return { ok: true, error: null as string | null };
+		} catch (err) {
+			logger.error("Error dropping user:", err);
+			return {
+				ok: false,
+				error: `Failed to drop user: ${err instanceof Error ? err.message : String(err)}`,
+			};
+		}
+	},
+);
+
+// Grant roles to an existing user.
+export const grantRolesToUser = command(
+	z.object({
+		server: z.string(),
+		username: z.string(),
+		roles: z.array(roleRefSchema),
+	}),
+	async ({ server, username, roles }) => {
+		logger.log("grantRolesToUser called with payload:", { server, username, roles });
+		checkReadOnly();
+		const mongo = await getMongo();
+		const client = mongo.getClient(server);
+		const admin = client.db("admin");
+		try {
+			const decodedRoles = JsonEncoder.decode(roles);
+			await admin.command({
+				grantRolesToUser: username,
+				roles: decodedRoles,
+			});
+			return { ok: true, error: null as string | null };
+		} catch (err) {
+			logger.error("Error granting roles to user:", err);
+			return {
+				ok: false,
+				error: `Failed to grant roles: ${err instanceof Error ? err.message : String(err)}`,
+			};
+		}
+	},
+);
+
+// Revoke roles from an existing user.
+export const revokeRolesFromUser = command(
+	z.object({
+		server: z.string(),
+		username: z.string(),
+		roles: z.array(roleRefSchema),
+	}),
+	async ({ server, username, roles }) => {
+		logger.log("revokeRolesFromUser called with payload:", { server, username, roles });
+		checkReadOnly();
+		const mongo = await getMongo();
+		const client = mongo.getClient(server);
+		const admin = client.db("admin");
+		try {
+			const decodedRoles = JsonEncoder.decode(roles);
+			await admin.command({
+				revokeRolesFromUser: username,
+				roles: decodedRoles,
+			});
+			return { ok: true, error: null as string | null };
+		} catch (err) {
+			logger.error("Error revoking roles from user:", err);
+			return {
+				ok: false,
+				error: `Failed to revoke roles: ${err instanceof Error ? err.message : String(err)}`,
+			};
+		}
+	},
+);
+
+// Reset a user's password.
+export const updateUserPassword = command(
+	z.object({
+		server: z.string(),
+		username: z.string(),
+		password: z.string(),
+	}),
+	async ({ server, username, password }) => {
+		logger.log("updateUserPassword called with payload:", { server, username });
+		checkReadOnly();
+		const mongo = await getMongo();
+		const client = mongo.getClient(server);
+		const admin = client.db("admin");
+		try {
+			await admin.command({
+				updateUser: username,
+				pwd: password,
+			});
+			return { ok: true, error: null as string | null };
+		} catch (err) {
+			logger.error("Error updating user password:", err);
+			return {
+				ok: false,
+				error: `Failed to update password: ${err instanceof Error ? err.message : String(err)}`,
+			};
+		}
+	},
+);

--- a/src/api/servers.remote.ts
+++ b/src/api/servers.remote.ts
@@ -1120,12 +1120,12 @@ export const listUsers = query(z.object({ server: z.string() }), async ({ server
 	const client = mongo.getClient(server);
 	const admin = client.db("admin");
 	try {
-		// `usersInfo: 1` lists all users in the current db (admin) — which on a
-		// cluster means every user. `showPrivileges: true` is NOT allowed with a
-		// non-exact (all-users) query unless the caller has grantRole privileges,
-		// so we list first, then fetch each user's resolved privileges via an
-		// exact-match query (which MongoDB always permits).
-		const result = await admin.command({ usersInfo: 1 });
+		// `{ forAllDBs: true }` lists users on every authentication database
+		// cluster-wide (not just admin). `showPrivileges: true` is NOT allowed
+		// with a non-exact (all-users) query unless the caller has grantRole
+		// privileges, so we list first, then fetch each user's resolved
+		// privileges via an exact-match query (which MongoDB always permits).
+		const result = await admin.command({ usersInfo: { forAllDBs: true } });
 		const users = (result.users ?? []) as Array<{ user: string; db: string }>;
 
 		const usersWithPrivs = await Promise.all(

--- a/src/routes/servers/[server]/databases/+page.svelte
+++ b/src/routes/servers/[server]/databases/+page.svelte
@@ -51,6 +51,15 @@
 </script>
 
 <Panel title="Databases on {data.server}">
+	{#snippet actions()}
+		<a
+			href={resolve(`/servers/${encodeURIComponent(data.server)}/users`)}
+			class="btn btn-outline-primary btn-sm"
+			title="Manage MongoDB users & roles"
+		>
+			Users
+		</a>
+	{/snippet}
 	<table class="table">
 		<thead>
 			<tr>

--- a/src/routes/servers/[server]/users/+page.server.ts
+++ b/src/routes/servers/[server]/users/+page.server.ts
@@ -9,19 +9,44 @@ export const load: PageServerLoad = async ({ params, depends }) => {
 	const client = mongo.getClient(params.server);
 	const admin = client.db("admin");
 
-	// The users / roles lists are fetched via remote commands (which run the
-	// admin DB commands with showPrivileges), but we also need the list of
-	// databases so role assignments can target the right db. Stream them so the
-	// page renders immediately and fills in when each resolves.
+	// Fetch all users. `showPrivileges: true` requires exact-match usersInfo
+	// queries (MongoDB rejects `usersInfo: 1` + `showPrivileges` unless the
+	// connected user has grantRole on the db). So we list all users first
+	// (which always returns each user's direct `roles`), then fetch each
+	// user's resolved privileges via an exact-match query. The per-user fetch
+	// is non-fatal — if it fails we still show the user with their roles.
 	const usersPromise = (async () => {
 		try {
-			const result = await admin.command({ usersInfo: 1, showPrivileges: true });
-			return result.users ?? [];
+			const result = await admin.command({ usersInfo: 1 });
+			const users = (result.users ?? []) as Array<{ user: string; db: string }>;
+
+			const usersWithPrivs = await Promise.all(
+				users.map(async (u) => {
+					try {
+						const info = await admin.command({
+							usersInfo: { user: u.user, db: u.db },
+							showPrivileges: true,
+						});
+						const detail = (info.users ?? [])[0] ?? {};
+						return { ...u, ...detail };
+					} catch (err) {
+						// Privilege resolution failed for this user — keep the base record
+						logger.error(`Error getting privileges for user ${u.user}:`, err);
+						return u;
+					}
+				}),
+			);
+
+			// JSON round-trip to strip any MongoDB special types for safe streaming
+			return { data: JSON.parse(JSON.stringify(usersWithPrivs)), error: null as string | null };
 		} catch (err) {
 			logger.error(`Error getting users for server ${params.server}:`, err);
-			throw err;
+			return {
+				data: [],
+				error: `Failed to list users: ${err instanceof Error ? err.message : String(err)}`,
+			};
 		}
-	})().catch((err) => err);
+	})();
 
 	const rolesPromise = (async () => {
 		try {
@@ -30,22 +55,29 @@ export const load: PageServerLoad = async ({ params, depends }) => {
 				showBuiltinRoles: true,
 				showPrivileges: true,
 			});
-			return result.roles ?? [];
+			return { data: JSON.parse(JSON.stringify(result.roles ?? [])), error: null as string | null };
 		} catch (err) {
 			logger.error(`Error getting roles for server ${params.server}:`, err);
-			throw err;
+			return {
+				data: [],
+				error: `Failed to list roles: ${err instanceof Error ? err.message : String(err)}`,
+			};
 		}
-	})().catch((err) => err);
+	})();
 
 	const databasesPromise = (async () => {
 		try {
 			const results = await client.db("test").admin().listDatabases();
-			return mongo.filterDatabases(results.databases).map((d) => d.name);
+			return {
+				data: mongo.filterDatabases(results.databases).map((d) => d.name),
+				error: null as string | null,
+			};
 		} catch (err) {
 			logger.error(`Error getting databases for server ${params.server}:`, err);
-			throw err;
+			// Non-critical — the UI falls back to ["admin"]
+			return { data: [] as string[], error: null as string | null };
 		}
-	})().catch((err) => err);
+	})();
 
 	return {
 		server: params.server,

--- a/src/routes/servers/[server]/users/+page.server.ts
+++ b/src/routes/servers/[server]/users/+page.server.ts
@@ -9,15 +9,17 @@ export const load: PageServerLoad = async ({ params, depends }) => {
 	const client = mongo.getClient(params.server);
 	const admin = client.db("admin");
 
-	// Fetch all users. `showPrivileges: true` requires exact-match usersInfo
-	// queries (MongoDB rejects `usersInfo: 1` + `showPrivileges` unless the
-	// connected user has grantRole on the db). So we list all users first
-	// (which always returns each user's direct `roles`), then fetch each
-	// user's resolved privileges via an exact-match query. The per-user fetch
-	// is non-fatal — if it fails we still show the user with their roles.
+	// Fetch all users across *every* authentication database. `usersInfo: 1`
+	// only returns users defined on the current db (admin); users created on
+	// other databases would be invisible. `{ forAllDBs: true }` lists users on
+	// all databases cluster-wide. `showPrivileges: true` is not allowed with a
+	// non-exact (all-users) query unless the caller has grantRole privileges,
+	// so we list first, then fetch each user's resolved privileges via an
+	// exact-match query (always permitted). The per-user fetch is non-fatal —
+	// if it fails we still show the user with their roles.
 	const usersPromise = (async () => {
 		try {
-			const result = await admin.command({ usersInfo: 1 });
+			const result = await admin.command({ usersInfo: { forAllDBs: true } });
 			const users = (result.users ?? []) as Array<{ user: string; db: string }>;
 
 			const usersWithPrivs = await Promise.all(

--- a/src/routes/servers/[server]/users/+page.server.ts
+++ b/src/routes/servers/[server]/users/+page.server.ts
@@ -1,0 +1,56 @@
+import { logger } from "$lib/server/logger";
+import { getMongo } from "$lib/server/mongo";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async ({ params, depends }) => {
+	depends("app:users");
+
+	const mongo = await getMongo();
+	const client = mongo.getClient(params.server);
+	const admin = client.db("admin");
+
+	// The users / roles lists are fetched via remote commands (which run the
+	// admin DB commands with showPrivileges), but we also need the list of
+	// databases so role assignments can target the right db. Stream them so the
+	// page renders immediately and fills in when each resolves.
+	const usersPromise = (async () => {
+		try {
+			const result = await admin.command({ usersInfo: 1, showPrivileges: true });
+			return result.users ?? [];
+		} catch (err) {
+			logger.error(`Error getting users for server ${params.server}:`, err);
+			throw err;
+		}
+	})().catch((err) => err);
+
+	const rolesPromise = (async () => {
+		try {
+			const result = await admin.command({
+				rolesInfo: 1,
+				showBuiltinRoles: true,
+				showPrivileges: true,
+			});
+			return result.roles ?? [];
+		} catch (err) {
+			logger.error(`Error getting roles for server ${params.server}:`, err);
+			throw err;
+		}
+	})().catch((err) => err);
+
+	const databasesPromise = (async () => {
+		try {
+			const results = await client.db("test").admin().listDatabases();
+			return mongo.filterDatabases(results.databases).map((d) => d.name);
+		} catch (err) {
+			logger.error(`Error getting databases for server ${params.server}:`, err);
+			throw err;
+		}
+	})().catch((err) => err);
+
+	return {
+		server: params.server,
+		users: usersPromise,
+		roles: rolesPromise,
+		databases: databasesPromise,
+	};
+};

--- a/src/routes/servers/[server]/users/+page.svelte
+++ b/src/routes/servers/[server]/users/+page.svelte
@@ -31,23 +31,33 @@
 	let resolvedRoles = $state<RolesResult | null>(null);
 	let resolvedDatabases = $state<DatabasesResult | null>(null);
 
+	// Token guards: only the latest promise's result is accepted, so a stale
+	// in-flight promise from a previous server / invalidate can't overwrite
+	// fresher data.
+	let usersToken = 0;
+	let rolesToken = 0;
+	let databasesToken = 0;
+
 	$effect(() => {
+		const token = ++usersToken;
 		data.users.then((r) => {
-			if (!resolvedUsers) {
+			if (token === usersToken) {
 				resolvedUsers = r;
 			}
 		});
 	});
 	$effect(() => {
+		const token = ++rolesToken;
 		data.roles.then((r) => {
-			if (!resolvedRoles) {
+			if (token === rolesToken) {
 				resolvedRoles = r;
 			}
 		});
 	});
 	$effect(() => {
+		const token = ++databasesToken;
 		data.databases.then((r) => {
-			if (!resolvedDatabases) {
+			if (token === databasesToken) {
 				resolvedDatabases = r;
 			}
 		});
@@ -60,6 +70,7 @@
 	let creatingUser = $state(false);
 	let newUsername = $state("");
 	let newPassword = $state("");
+	let newUserDb = $state("admin");
 	let newRole = $state("read");
 	let newRoleDb = $state("admin");
 	let newRoles = $state<Array<{ role: string; db: string }>>([]);
@@ -67,6 +78,7 @@
 	function openCreateModal() {
 		newUsername = "";
 		newPassword = "";
+		newUserDb = "admin";
 		newRole = "read";
 		newRoleDb = "admin";
 		newRoles = [];
@@ -96,6 +108,7 @@
 				server: data.server,
 				username: newUsername,
 				password: newPassword,
+				db: newUserDb,
 				roles,
 			});
 			if (result.error) {
@@ -103,9 +116,9 @@
 			}
 			notificationStore.notifySuccess(`User "${newUsername}" created successfully`);
 			showCreateModal = false;
-			await invalidate("app:users");
+			// Clear the cached result so the streaming promise re-resolves fresh data
 			resolvedUsers = null;
-			resolvedDatabases = null;
+			await invalidate("app:users");
 		} catch (error) {
 			notificationStore.notifyError(error, "Failed to create user");
 		} finally {
@@ -115,12 +128,18 @@
 
 	// ── Drop user modal ───────────────────────────────────────────────────
 	let showDropModal = $state(false);
-	let userToDrop = $state<string | null>(null);
+	let userToDrop = $state<{ user: string; db: string } | null>(null);
 	let droppingUser = $state(false);
+	// keyed by `${user}@${db}` so two users with the same name on different dbs
+	// don't share loading state
 	const operatingUsers = new SvelteSet<string>();
 
-	function openDropModal(username: string) {
-		userToDrop = username;
+	function userKey(u: string, db: string): string {
+		return `${u}@${db}`;
+	}
+
+	function openDropModal(user: { user: string; db: string }) {
+		userToDrop = user;
 		showDropModal = true;
 	}
 
@@ -133,29 +152,31 @@
 		if (!userToDrop) {
 			return;
 		}
-		const username = userToDrop;
+		const { user: username, db } = userToDrop;
+		const key = userKey(username, db);
 		droppingUser = true;
-		operatingUsers.add(username);
+		operatingUsers.add(key);
 		try {
-			const result = await dropUserCommand({ server: data.server, username });
+			const result = await dropUserCommand({ server: data.server, username, db });
 			if (result.error) {
 				throw new Error(result.error);
 			}
 			notificationStore.notifySuccess(`User "${username}" dropped successfully`);
 			closeDropModal();
-			await invalidate("app:users");
 			resolvedUsers = null;
+			await invalidate("app:users");
 		} catch (error) {
 			notificationStore.notifyError(error, "Failed to drop user");
 		} finally {
 			droppingUser = false;
-			operatingUsers.delete(username);
+			operatingUsers.delete(key);
 		}
 	}
 
 	// ── Edit roles modal ──────────────────────────────────────────────────
 	let showRolesModal = $state(false);
 	let rolesUser = $state<string | null>(null);
+	let rolesUserDb = $state<string>("admin");
 	let currentRoles = $state<Array<{ role: string; db: string }>>([]);
 	let inheritedPrivileges = $state<unknown>(null);
 	let addRoleName = $state("read");
@@ -169,6 +190,7 @@
 		inheritedPrivileges?: unknown;
 	}) {
 		rolesUser = user.user;
+		rolesUserDb = user.db;
 		currentRoles = user.roles.map((r) => ({ role: r.role, db: r.db }));
 		inheritedPrivileges = user.inheritedPrivileges ?? null;
 		addRoleName = "read";
@@ -179,6 +201,7 @@
 	function closeRolesModal() {
 		showRolesModal = false;
 		rolesUser = null;
+		rolesUserDb = "admin";
 		currentRoles = [];
 		inheritedPrivileges = null;
 	}
@@ -192,6 +215,7 @@
 			const result = await revokeRolesFromUserCommand({
 				server: data.server,
 				username: rolesUser,
+				db: rolesUserDb,
 				roles: [role],
 			});
 			if (result.error) {
@@ -199,8 +223,8 @@
 			}
 			currentRoles = currentRoles.filter((r) => !(r.role === role.role && r.db === role.db));
 			notificationStore.notifySuccess(`Revoked ${role.role}@${role.db} from ${rolesUser}`);
-			await invalidate("app:users");
 			resolvedUsers = null;
+			await invalidate("app:users");
 		} catch (error) {
 			notificationStore.notifyError(error, "Failed to revoke role");
 		} finally {
@@ -223,6 +247,7 @@
 			const result = await grantRolesToUserCommand({
 				server: data.server,
 				username: rolesUser,
+				db: rolesUserDb,
 				roles: [role],
 			});
 			if (result.error) {
@@ -230,8 +255,8 @@
 			}
 			currentRoles = [...currentRoles, role];
 			notificationStore.notifySuccess(`Granted ${role.role}@${role.db} to ${rolesUser}`);
-			await invalidate("app:users");
 			resolvedUsers = null;
+			await invalidate("app:users");
 		} catch (error) {
 			notificationStore.notifyError(error, "Failed to grant role");
 		} finally {
@@ -241,12 +266,12 @@
 
 	// ── Reset password modal ──────────────────────────────────────────────
 	let showPasswordModal = $state(false);
-	let passwordUser = $state<string | null>(null);
+	let passwordUser = $state<{ user: string; db: string } | null>(null);
 	let newPasswordValue = $state("");
 	let updatingPassword = $state(false);
 
-	function openPasswordModal(username: string) {
-		passwordUser = username;
+	function openPasswordModal(user: { user: string; db: string }) {
+		passwordUser = user;
 		newPasswordValue = "";
 		showPasswordModal = true;
 	}
@@ -261,17 +286,19 @@
 		if (!passwordUser || !newPasswordValue) {
 			return;
 		}
+		const { user: username, db } = passwordUser;
 		updatingPassword = true;
 		try {
 			const result = await updateUserPasswordCommand({
 				server: data.server,
-				username: passwordUser,
+				username,
+				db,
 				password: newPasswordValue,
 			});
 			if (result.error) {
 				throw new Error(result.error);
 			}
-			notificationStore.notifySuccess(`Password updated for "${passwordUser}"`);
+			notificationStore.notifySuccess(`Password updated for "${username}"`);
 			closePasswordModal();
 		} catch (error) {
 			notificationStore.notifyError(error, "Failed to update password");
@@ -407,8 +434,8 @@
 							</tr>
 						</thead>
 						<tbody>
-							{#each res.data as user (user.user)}
-								{@const isLoading = operatingUsers.has(user.user)}
+							{#each res.data as user (userKey(user.user, user.db))}
+								{@const isLoading = operatingUsers.has(userKey(user.user, user.db))}
 								<tr class="group" class:opacity-50={isLoading}>
 									<td class="name-cell">
 										<span class="font-mono text-sm">{user.user}</span>
@@ -474,14 +501,14 @@
 												</button>
 												<button
 													class="btn btn-outline-light px-2 py-1 text-xs whitespace-nowrap"
-													onclick={() => openPasswordModal(user.user)}
+													onclick={() => openPasswordModal(user)}
 													disabled={isLoading}
 												>
 													Password
 												</button>
 												<button
 													class="btn btn-outline-danger px-2 py-1 text-xs whitespace-nowrap"
-													onclick={() => openDropModal(user.user)}
+													onclick={() => openDropModal(user)}
 													disabled={isLoading}
 												>
 													Drop
@@ -529,6 +556,24 @@
 				class="w-full p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm focus:outline-none focus:ring-2"
 				style="color: var(--text); --tw-ring-color: var(--link);"
 			/>
+		</div>
+		<div>
+			<label for="new-user-db" class="block text-sm font-semibold mb-2" style="color: var(--text);">
+				Authentication Database
+			</label>
+			<p class="text-xs mb-2" style="color: var(--text-darker);">
+				The database the user is created on. Usually <code>admin</code>.
+			</p>
+			<select
+				id="new-user-db"
+				bind:value={newUserDb}
+				class="w-full p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm"
+				style="color: var(--text);"
+			>
+				{#each databaseNames as db (db)}
+					<option value={db}>{db}</option>
+				{/each}
+			</select>
 		</div>
 		<div>
 			<div class="block text-sm font-semibold mb-2" style="color: var(--text);">Roles</div>
@@ -587,7 +632,9 @@
 <!-- Drop user modal -->
 <Modal show={showDropModal} onclose={closeDropModal} title="Drop User">
 	<p>
-		Are you sure you want to drop the user <strong>{userToDrop}</strong>? This action cannot be undone.
+		Are you sure you want to drop the user <strong>{userToDrop?.user}</strong>
+		{#if userToDrop?.db && userToDrop.db !== "admin"}
+			on <strong>{userToDrop.db}</strong>{/if}? This action cannot be undone.
 	</p>
 	<p class="text-sm mt-2" style="color: var(--text-darker);">
 		The user will lose all access to the database. They can be recreated, but their credentials cannot be recovered.
@@ -670,7 +717,7 @@
 </Modal>
 
 <!-- Reset password modal -->
-<Modal show={showPasswordModal} onclose={closePasswordModal} title={`Reset Password — ${passwordUser ?? ""}`}>
+<Modal show={showPasswordModal} onclose={closePasswordModal} title={`Reset Password — ${passwordUser?.user ?? ""}`}>
 	<div class="space-y-4">
 		<div>
 			<label for="new-pwd" class="block text-sm font-semibold mb-2" style="color: var(--text);">

--- a/src/routes/servers/[server]/users/+page.svelte
+++ b/src/routes/servers/[server]/users/+page.svelte
@@ -1,0 +1,834 @@
+<script lang="ts">
+	import {
+		createUser as createUserCommand,
+		dropUser as dropUserCommand,
+		grantRolesToUser as grantRolesToUserCommand,
+		revokeRolesFromUser as revokeRolesFromUserCommand,
+		updateUserPassword as updateUserPasswordCommand,
+	} from "$api/servers.remote";
+	import { invalidate } from "$app/navigation";
+	import JsonValue from "$lib/components/JsonValue.svelte";
+	import Modal from "$lib/components/Modal.svelte";
+	import Panel from "$lib/components/Panel.svelte";
+	import { notificationStore } from "$lib/stores/notifications.svelte";
+	import { SvelteSet } from "svelte/reactivity";
+	import type { PageData } from "./$types";
+
+	let { data }: { data: PageData } = $props();
+
+	const readOnly = $derived(data.readOnly);
+
+	// Resolve the streamed promises once so we can mutate the local copy after
+	// grant/revoke without re-fetching from the server every time.
+	type User = PageData["users"] extends Promise<infer U> ? U : never;
+	type Role = PageData["roles"] extends Promise<infer R> ? R : never;
+	type Database = PageData["databases"] extends Promise<infer D> ? D : never;
+
+	let resolvedUsers = $state<User | null>(null);
+	let resolvedRoles = $state<Role | null>(null);
+	let resolvedDatabases = $state<Database | null>(null);
+
+	$effect(() => {
+		data.users.then((r) => {
+			if (!resolvedUsers) {
+				resolvedUsers = r;
+			}
+		});
+	});
+	$effect(() => {
+		data.roles.then((r) => {
+			if (!resolvedRoles) {
+				resolvedRoles = r;
+			}
+		});
+	});
+	$effect(() => {
+		data.databases.then((r) => {
+			if (!resolvedDatabases) {
+				resolvedDatabases = r;
+			}
+		});
+	});
+
+	const usersData = $derived(resolvedUsers ?? data.users);
+	const rolesData = $derived(resolvedRoles ?? data.roles);
+
+	// ── Create user modal ──────────────────────────────────────────────────
+	let showCreateModal = $state(false);
+	let creatingUser = $state(false);
+	let newUsername = $state("");
+	let newPassword = $state("");
+	let newRole = $state("read");
+	let newRoleDb = $state("admin");
+	let newRoles = $state<Array<{ role: string; db: string }>>([]);
+
+	function openCreateModal() {
+		newUsername = "";
+		newPassword = "";
+		newRole = "read";
+		newRoleDb = "admin";
+		newRoles = [];
+		showCreateModal = true;
+	}
+
+	function addNewRole() {
+		if (!newRole.trim()) {
+			return;
+		}
+		newRoles = [...newRoles, { role: newRole.trim(), db: newRoleDb }];
+		newRole = "read";
+	}
+
+	function removeNewRole(idx: number) {
+		newRoles = newRoles.filter((_, i) => i !== idx);
+	}
+
+	async function confirmCreateUser() {
+		if (!newUsername || !newPassword) {
+			return;
+		}
+		creatingUser = true;
+		const roles = newRoles.length > 0 ? newRoles : [];
+		try {
+			const result = await createUserCommand({
+				server: data.server,
+				username: newUsername,
+				password: newPassword,
+				roles,
+			});
+			if (result.error) {
+				throw new Error(result.error);
+			}
+			notificationStore.notifySuccess(`User "${newUsername}" created successfully`);
+			showCreateModal = false;
+			await invalidate("app:users");
+			resolvedUsers = null;
+			resolvedDatabases = null;
+		} catch (error) {
+			notificationStore.notifyError(error, "Failed to create user");
+		} finally {
+			creatingUser = false;
+		}
+	}
+
+	// ── Drop user modal ───────────────────────────────────────────────────
+	let showDropModal = $state(false);
+	let userToDrop = $state<string | null>(null);
+	let droppingUser = $state(false);
+	const operatingUsers = new SvelteSet<string>();
+
+	function openDropModal(username: string) {
+		userToDrop = username;
+		showDropModal = true;
+	}
+
+	function closeDropModal() {
+		showDropModal = false;
+		userToDrop = null;
+	}
+
+	async function confirmDropUser() {
+		if (!userToDrop) {
+			return;
+		}
+		const username = userToDrop;
+		droppingUser = true;
+		operatingUsers.add(username);
+		try {
+			const result = await dropUserCommand({ server: data.server, username });
+			if (result.error) {
+				throw new Error(result.error);
+			}
+			notificationStore.notifySuccess(`User "${username}" dropped successfully`);
+			closeDropModal();
+			await invalidate("app:users");
+			resolvedUsers = null;
+		} catch (error) {
+			notificationStore.notifyError(error, "Failed to drop user");
+		} finally {
+			droppingUser = false;
+			operatingUsers.delete(username);
+		}
+	}
+
+	// ── Edit roles modal ──────────────────────────────────────────────────
+	let showRolesModal = $state(false);
+	let rolesUser = $state<string | null>(null);
+	let currentRoles = $state<Array<{ role: string; db: string }>>([]);
+	let inheritedPrivileges = $state<unknown>(null);
+	let addRoleName = $state("read");
+	let addRoleDb = $state("admin");
+	let updatingRoles = $state(false);
+
+	function openRolesModal(user: {
+		user: string;
+		db: string;
+		roles: Array<{ role: string; db: string }>;
+		inheritedPrivileges?: unknown;
+	}) {
+		rolesUser = user.user;
+		currentRoles = user.roles.map((r) => ({ role: r.role, db: r.db }));
+		inheritedPrivileges = user.inheritedPrivileges ?? null;
+		addRoleName = "read";
+		addRoleDb = user.db;
+		showRolesModal = true;
+	}
+
+	function closeRolesModal() {
+		showRolesModal = false;
+		rolesUser = null;
+		currentRoles = [];
+		inheritedPrivileges = null;
+	}
+
+	async function removeRole(role: { role: string; db: string }) {
+		if (!rolesUser || updatingRoles) {
+			return;
+		}
+		updatingRoles = true;
+		try {
+			const result = await revokeRolesFromUserCommand({
+				server: data.server,
+				username: rolesUser,
+				roles: [role],
+			});
+			if (result.error) {
+				throw new Error(result.error);
+			}
+			currentRoles = currentRoles.filter((r) => !(r.role === role.role && r.db === role.db));
+			notificationStore.notifySuccess(`Revoked ${role.role}@${role.db} from ${rolesUser}`);
+			await invalidate("app:users");
+			resolvedUsers = null;
+		} catch (error) {
+			notificationStore.notifyError(error, "Failed to revoke role");
+		} finally {
+			updatingRoles = false;
+		}
+	}
+
+	async function addRole() {
+		if (!rolesUser || !addRoleName.trim() || updatingRoles) {
+			return;
+		}
+		const role = { role: addRoleName.trim(), db: addRoleDb };
+		// Skip if already present
+		if (currentRoles.some((r) => r.role === role.role && r.db === role.db)) {
+			notificationStore.notify(`${role.role}@${role.db} is already assigned`, "info");
+			return;
+		}
+		updatingRoles = true;
+		try {
+			const result = await grantRolesToUserCommand({
+				server: data.server,
+				username: rolesUser,
+				roles: [role],
+			});
+			if (result.error) {
+				throw new Error(result.error);
+			}
+			currentRoles = [...currentRoles, role];
+			notificationStore.notifySuccess(`Granted ${role.role}@${role.db} to ${rolesUser}`);
+			await invalidate("app:users");
+			resolvedUsers = null;
+		} catch (error) {
+			notificationStore.notifyError(error, "Failed to grant role");
+		} finally {
+			updatingRoles = false;
+		}
+	}
+
+	// ── Reset password modal ──────────────────────────────────────────────
+	let showPasswordModal = $state(false);
+	let passwordUser = $state<string | null>(null);
+	let newPasswordValue = $state("");
+	let updatingPassword = $state(false);
+
+	function openPasswordModal(username: string) {
+		passwordUser = username;
+		newPasswordValue = "";
+		showPasswordModal = true;
+	}
+
+	function closePasswordModal() {
+		showPasswordModal = false;
+		passwordUser = null;
+		newPasswordValue = "";
+	}
+
+	async function confirmUpdatePassword() {
+		if (!passwordUser || !newPasswordValue) {
+			return;
+		}
+		updatingPassword = true;
+		try {
+			const result = await updateUserPasswordCommand({
+				server: data.server,
+				username: passwordUser,
+				password: newPasswordValue,
+			});
+			if (result.error) {
+				throw new Error(result.error);
+			}
+			notificationStore.notifySuccess(`Password updated for "${passwordUser}"`);
+			closePasswordModal();
+		} catch (error) {
+			notificationStore.notifyError(error, "Failed to update password");
+		} finally {
+			updatingPassword = false;
+		}
+	}
+
+	// Available role names (deduped, sorted) from the roles list for the dropdowns.
+	const availableRoleNames = $derived.by(() => {
+		const roles = rolesData;
+		if (!roles || roles instanceof Error) {
+			return ["read", "readWrite", "dbAdmin", "userAdmin", "clusterAdmin"].sort();
+		}
+		const names: Record<string, true> = {};
+		for (const r of roles) {
+			if (r?.role) {
+				names[r.role] = true;
+			}
+		}
+		return Object.keys(names).sort();
+	});
+
+	// Database names for the role-target dropdown.
+	const databaseNames = $derived.by(() => {
+		const dbs = resolvedDatabases;
+		if (!dbs || dbs instanceof Error || !Array.isArray(dbs)) {
+			return ["admin"];
+		}
+		const names = (dbs as unknown[]).filter((d): d is string => typeof d === "string");
+		return names.length > 0 ? names : ["admin"];
+	});
+
+	// Render a role reference as "role@db" (admin db implied when omitted).
+	function roleLabel(role: { role: string; db?: string } | string): string {
+		if (typeof role === "string") {
+			return `${role}@admin`;
+		}
+		return `${role.role}@${role.db ?? "admin"}`;
+	}
+
+	// Group inherited privileges by database for display.
+	type Privilege = { resource: { db?: string; collection?: string }; actions: string[] };
+	type GroupedPriv = { db: string; collections: Array<{ collection: string; actions: string[] }> };
+	function groupPrivileges(privs: unknown): GroupedPriv[] {
+		if (!Array.isArray(privs)) {
+			return [];
+		}
+		// db -> collection -> action set, using plain objects to avoid the
+		// svelte/prefer-svelte-reactivity lint rule (these are not reactive).
+		const byDb: Record<string, Record<string, Record<string, true>>> = {};
+		for (const p of privs as Privilege[]) {
+			const db = p?.resource?.db ?? "*";
+			const coll = p?.resource?.collection ?? "*";
+			byDb[db] ??= {};
+			byDb[db][coll] ??= {};
+			for (const a of p.actions ?? []) {
+				byDb[db][coll][a] = true;
+			}
+		}
+		return Object.keys(byDb)
+			.sort()
+			.map((db) => ({
+				db,
+				collections: Object.keys(byDb[db])
+					.sort()
+					.map((collection) => ({
+						collection,
+						actions: Object.keys(byDb[db][collection]).sort(),
+					})),
+			}));
+	}
+</script>
+
+{#await usersData}
+	<Panel title="Users">
+		<div class="loading">Loading users...</div>
+	</Panel>
+{:then result}
+	{#if result instanceof Error}
+		<Panel title="Users">
+			<div class="p-4">
+				<p class="error">Error loading users: {result.message}</p>
+				<p class="text-sm mt-2" style="color: var(--text-darker);">
+					User management requires the connected MongoDB user to have the <code>userAdmin</code> or
+					<code>userAdminAnyDatabase</code> role (or equivalent) on the <code>admin</code> database.
+				</p>
+			</div>
+		</Panel>
+	{:else}
+		<!-- Action buttons -->
+		<div class="mb-4 flex gap-3">
+			{#if !readOnly}
+				<button class="btn btn-success btn-sm" type="button" onclick={openCreateModal}>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						class="w-4 h-4 inline mr-1"
+					>
+						<path d="M12 5v14M5 12h14" />
+					</svg>
+					Create User
+				</button>
+			{/if}
+		</div>
+
+		{#if result.length === 0}
+			<Panel title="Users">
+				<div class="text-center p-4" style="color: var(--text-darker)">No users found</div>
+			</Panel>
+		{:else}
+			<Panel title={`Users on ${data.server}`}>
+				<div class="table-wrapper">
+					<table class="table">
+						<thead>
+							<tr>
+								<th class="name-column">Username</th>
+								<th>Database</th>
+								<th>Roles</th>
+								<th>Privileges</th>
+								{#if !readOnly}
+									<th style="width: 280px">Actions</th>
+								{/if}
+							</tr>
+						</thead>
+						<tbody>
+							{#each result as user (user.user)}
+								{@const isLoading = operatingUsers.has(user.user)}
+								<tr class="group" class:opacity-50={isLoading}>
+									<td class="name-cell">
+										<span class="font-mono text-sm">{user.user}</span>
+									</td>
+									<td>
+										<span class="text-sm">{user.db}</span>
+									</td>
+									<td>
+										<div class="flex flex-wrap gap-2">
+											{#if user.roles && user.roles.length > 0}
+												{#each user.roles as role (roleLabel(role))}
+													<span class="role-badge" title={`${role.role} on ${role.db}`}>
+														{roleLabel(role)}
+													</span>
+												{/each}
+											{:else}
+												<span style="color: var(--text-darker);">No roles</span>
+											{/if}
+										</div>
+									</td>
+									<td>
+										<details class="cursor-pointer">
+											<summary class="details-link">
+												View {user.inheritedPrivileges?.length ?? 0} privilege
+												{user.inheritedPrivileges?.length === 1 ? "" : "s"}
+											</summary>
+											<div class="details-content">
+												{#if user.inheritedPrivileges && user.inheritedPrivileges.length > 0}
+													<div class="privilege-groups">
+														{#each groupPrivileges(user.inheritedPrivileges) as group (group.db)}
+															<div class="priv-group">
+																<div class="priv-db">{group.db}</div>
+																<div class="priv-colls">
+																	{#each group.collections as c (group.db + c.collection)}
+																		<div class="priv-coll">
+																			<span class="priv-coll-name" title={c.collection}>{c.collection}</span>
+																			<div class="priv-actions">
+																				{#each c.actions as action (action)}
+																					<span class="priv-action">{action}</span>
+																				{/each}
+																			</div>
+																		</div>
+																	{/each}
+																</div>
+															</div>
+														{/each}
+													</div>
+												{:else}
+													<span style="color: var(--text-darker);">No resolved privileges</span>
+												{/if}
+											</div>
+										</details>
+									</td>
+									{#if !readOnly}
+										<td>
+											<div class="flex gap-2 hidden group-hover:flex -my-2">
+												<button
+													class="btn btn-outline-primary btn-sm"
+													onclick={() => openRolesModal(user)}
+													disabled={isLoading}
+												>
+													Edit Roles
+												</button>
+												<button
+													class="btn btn-outline-light btn-sm"
+													onclick={() => openPasswordModal(user.user)}
+													disabled={isLoading}
+												>
+													Password
+												</button>
+												<button
+													class="btn btn-outline-danger btn-sm"
+													onclick={() => openDropModal(user.user)}
+													disabled={isLoading}
+												>
+													Drop
+												</button>
+											</div>
+										</td>
+									{/if}
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</Panel>
+		{/if}
+	{/if}
+{:catch err}
+	<Panel title="Users">
+		<div class="p-4">
+			<p class="error">Error loading users: {err}</p>
+		</div>
+	</Panel>
+{/await}
+
+<!-- Create user modal -->
+<Modal show={showCreateModal} onclose={() => (showCreateModal = false)} title="Create User" wide>
+	<div class="space-y-4">
+		<div>
+			<label for="new-username" class="block text-sm font-semibold mb-2" style="color: var(--text);">
+				Username <span style="color: var(--error);">*</span>
+			</label>
+			<input
+				id="new-username"
+				type="text"
+				bind:value={newUsername}
+				placeholder="username"
+				class="w-full p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm focus:outline-none focus:ring-2"
+				style="color: var(--text); --tw-ring-color: var(--link);"
+			/>
+		</div>
+		<div>
+			<label for="new-password" class="block text-sm font-semibold mb-2" style="color: var(--text);">
+				Password <span style="color: var(--error);">*</span>
+			</label>
+			<input
+				id="new-password"
+				type="password"
+				bind:value={newPassword}
+				placeholder="password"
+				class="w-full p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm focus:outline-none focus:ring-2"
+				style="color: var(--text); --tw-ring-color: var(--link);"
+			/>
+		</div>
+		<div>
+			<div class="block text-sm font-semibold mb-2" style="color: var(--text);">Roles</div>
+			<p class="text-xs mb-2" style="color: var(--text-darker);">
+				Optionally assign roles now. You can change them later via "Edit Roles".
+			</p>
+			<div class="flex gap-2 items-center">
+				<select
+					bind:value={newRole}
+					class="p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm"
+					style="color: var(--text);"
+				>
+					{#each availableRoleNames as name (name)}
+						<option value={name}>{name}</option>
+					{/each}
+				</select>
+				<select
+					bind:value={newRoleDb}
+					class="p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm"
+					style="color: var(--text);"
+				>
+					{#each databaseNames as db (db)}
+						<option value={db}>{db}</option>
+					{/each}
+				</select>
+				<button class="btn btn-outline-primary btn-sm" onclick={addNewRole} type="button">Add</button>
+			</div>
+			{#if newRoles.length > 0}
+				<div class="flex flex-wrap gap-2 mt-2">
+					{#each newRoles as role, i (i)}
+						<span class="role-badge">
+							{roleLabel(role)}
+							<button type="button" class="role-remove" onclick={() => removeNewRole(i)} aria-label="Remove role"
+								>×</button
+							>
+						</span>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+	{#snippet footer()}
+		<button class="btn btn-default btn-sm" onclick={() => (showCreateModal = false)} disabled={creatingUser}>
+			Cancel
+		</button>
+		<button
+			class="btn btn-success btn-sm"
+			onclick={confirmCreateUser}
+			disabled={creatingUser || !newUsername || !newPassword}
+		>
+			{creatingUser ? "Creating..." : "Create User"}
+		</button>
+	{/snippet}
+</Modal>
+
+<!-- Drop user modal -->
+<Modal show={showDropModal} onclose={closeDropModal} title="Drop User">
+	<p>
+		Are you sure you want to drop the user <strong>{userToDrop}</strong>? This action cannot be undone.
+	</p>
+	<p class="text-sm mt-2" style="color: var(--text-darker);">
+		The user will lose all access to the database. They can be recreated, but their credentials cannot be recovered.
+	</p>
+	{#snippet footer()}
+		<button class="btn btn-default btn-sm" onclick={closeDropModal} disabled={droppingUser}>Cancel</button>
+		<button class="btn btn-outline-danger btn-sm" onclick={confirmDropUser} disabled={droppingUser}>
+			{droppingUser ? "Dropping..." : "Drop User"}
+		</button>
+	{/snippet}
+</Modal>
+
+<!-- Edit roles modal -->
+<Modal show={showRolesModal} onclose={closeRolesModal} title={`Edit Roles — ${rolesUser ?? ""}`} wide>
+	<div class="space-y-4">
+		<div>
+			<div class="block text-sm font-semibold mb-2" style="color: var(--text);">Current Roles</div>
+			{#if currentRoles.length > 0}
+				<div class="flex flex-wrap gap-2">
+					{#each currentRoles as role (roleLabel(role))}
+						<span class="role-badge">
+							{roleLabel(role)}
+							<button
+								type="button"
+								class="role-remove"
+								onclick={() => removeRole(role)}
+								disabled={updatingRoles}
+								aria-label="Remove role">×</button
+							>
+						</span>
+					{/each}
+				</div>
+			{:else}
+				<span style="color: var(--text-darker);">No roles assigned</span>
+			{/if}
+		</div>
+
+		<div>
+			<div class="block text-sm font-semibold mb-2" style="color: var(--text);">Grant a role</div>
+			<div class="flex gap-2 items-center">
+				<select
+					bind:value={addRoleName}
+					class="p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm"
+					style="color: var(--text);"
+				>
+					{#each availableRoleNames as name (name)}
+						<option value={name}>{name}</option>
+					{/each}
+				</select>
+				<select
+					bind:value={addRoleDb}
+					class="p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm"
+					style="color: var(--text);"
+				>
+					{#each databaseNames as db (db)}
+						<option value={db}>{db}</option>
+					{/each}
+				</select>
+				<button class="btn btn-outline-primary btn-sm" onclick={addRole} type="button" disabled={updatingRoles}>
+					Grant
+				</button>
+			</div>
+		</div>
+
+		{#if inheritedPrivileges}
+			<div>
+				<div class="block text-sm font-semibold mb-2" style="color: var(--text);">Resolved Privileges</div>
+				<p class="text-xs mb-2" style="color: var(--text-darker);">
+					Effective privileges inherited from all assigned roles.
+				</p>
+				<div class="priv-details">
+					<JsonValue value={inheritedPrivileges} autoCollapse collapsed />
+				</div>
+			</div>
+		{/if}
+	</div>
+	{#snippet footer()}
+		<button class="btn btn-default btn-sm" onclick={closeRolesModal}>Done</button>
+	{/snippet}
+</Modal>
+
+<!-- Reset password modal -->
+<Modal show={showPasswordModal} onclose={closePasswordModal} title={`Reset Password — ${passwordUser ?? ""}`}>
+	<div class="space-y-4">
+		<div>
+			<label for="new-pwd" class="block text-sm font-semibold mb-2" style="color: var(--text);">
+				New Password <span style="color: var(--error);">*</span>
+			</label>
+			<input
+				id="new-pwd"
+				type="password"
+				bind:value={newPasswordValue}
+				placeholder="new password"
+				class="w-full p-2 rounded border border-[var(--border-color)] bg-[var(--color-1)] text-sm focus:outline-none focus:ring-2"
+				style="color: var(--text); --tw-ring-color: var(--link);"
+			/>
+		</div>
+	</div>
+	{#snippet footer()}
+		<button class="btn btn-default btn-sm" onclick={closePasswordModal} disabled={updatingPassword}> Cancel </button>
+		<button
+			class="btn btn-primary btn-sm"
+			onclick={confirmUpdatePassword}
+			disabled={updatingPassword || !newPasswordValue}
+		>
+			{updatingPassword ? "Updating..." : "Update Password"}
+		</button>
+	{/snippet}
+</Modal>
+
+<style lang="postcss">
+	.table-wrapper {
+		overflow-x: auto;
+	}
+
+	.table tbody td {
+		vertical-align: top;
+	}
+
+	.name-column {
+		width: 20%;
+		min-width: 150px;
+		max-width: 300px;
+	}
+
+	.name-cell {
+		max-width: 300px;
+	}
+
+	.role-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		border-radius: 3px;
+		padding: 4px 8px;
+		font-size: 12px;
+		font-family: monospace;
+		background-color: var(--color-3);
+		color: var(--text);
+		border: 1px solid var(--color-4);
+	}
+
+	.role-remove {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		height: 16px;
+		border-radius: 3px;
+		font-size: 14px;
+		line-height: 1;
+		cursor: pointer;
+		color: var(--text-secondary);
+		background: transparent;
+		border: none;
+	}
+
+	.role-remove:hover:not(:disabled) {
+		background-color: var(--button-danger);
+		color: white;
+	}
+
+	.details-link {
+		font-size: 0.875rem;
+		color: var(--link);
+		cursor: pointer;
+	}
+
+	.details-link:hover {
+		text-decoration: underline;
+	}
+
+	.details-content {
+		margin-top: 8px;
+		border-radius: 4px;
+		padding: 12px;
+		font-size: 0.875rem;
+		background-color: var(--color-1);
+		border: 1px solid var(--border-color);
+		max-width: 600px;
+	}
+
+	.privilege-groups {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.priv-group {
+		border-left: 2px solid var(--color-4);
+		padding-left: 10px;
+	}
+
+	.priv-db {
+		font-family: monospace;
+		font-weight: 600;
+		margin-bottom: 4px;
+		color: var(--text);
+	}
+
+	.priv-colls {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.priv-coll {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.priv-coll-name {
+		font-family: monospace;
+		font-size: 12px;
+		color: var(--text-secondary);
+	}
+
+	.priv-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+	}
+
+	.priv-action {
+		display: inline-block;
+		padding: 1px 6px;
+		border-radius: 3px;
+		font-size: 11px;
+		font-family: monospace;
+		background-color: var(--color-3);
+		color: var(--text-secondary);
+		border: 1px solid var(--color-4);
+	}
+
+	.priv-details {
+		max-height: 300px;
+		overflow: auto;
+		border-radius: 4px;
+		padding: 12px;
+		background-color: var(--color-1);
+		border: 1px solid var(--border-color);
+		font-family: monospace;
+		font-size: 0.8rem;
+	}
+</style>

--- a/src/routes/servers/[server]/users/+page.svelte
+++ b/src/routes/servers/[server]/users/+page.svelte
@@ -18,15 +18,18 @@
 
 	const readOnly = $derived(data.readOnly);
 
-	// Resolve the streamed promises once so we can mutate the local copy after
-	// grant/revoke without re-fetching from the server every time.
-	type User = PageData["users"] extends Promise<infer U> ? U : never;
-	type Role = PageData["roles"] extends Promise<infer R> ? R : never;
-	type Database = PageData["databases"] extends Promise<infer D> ? D : never;
+	// Each streamed promise resolves to { data, error }. We unwrap into local
+	// state so we can optimistically update after grant/revoke without a full
+	// re-fetch, and so rendering never holds onto the unresolved promise.
+	type UsersResult = PageData["users"] extends Promise<infer U> ? U : never;
+	type RolesResult = PageData["roles"] extends Promise<infer R> ? R : never;
+	type DatabasesResult = PageData["databases"] extends Promise<infer D> ? D : never;
 
-	let resolvedUsers = $state<User | null>(null);
-	let resolvedRoles = $state<Role | null>(null);
-	let resolvedDatabases = $state<Database | null>(null);
+	type RoleDoc = RolesResult extends { data: infer R } ? R : never;
+
+	let resolvedUsers = $state<UsersResult | null>(null);
+	let resolvedRoles = $state<RolesResult | null>(null);
+	let resolvedDatabases = $state<DatabasesResult | null>(null);
 
 	$effect(() => {
 		data.users.then((r) => {
@@ -50,8 +53,7 @@
 		});
 	});
 
-	const usersData = $derived(resolvedUsers ?? data.users);
-	const rolesData = $derived(resolvedRoles ?? data.roles);
+	const usersResult = $derived(resolvedUsers ?? data.users);
 
 	// ── Create user modal ──────────────────────────────────────────────────
 	let showCreateModal = $state(false);
@@ -279,13 +281,16 @@
 	}
 
 	// Available role names (deduped, sorted) from the roles list for the dropdowns.
+	// These only render inside modals, which open after data has resolved, so
+	// deriving from the resolved state (null until loaded) is safe.
 	const availableRoleNames = $derived.by(() => {
-		const roles = rolesData;
-		if (!roles || roles instanceof Error) {
+		const res = resolvedRoles;
+		const roles = res?.data;
+		if (!res || res.error || !Array.isArray(roles)) {
 			return ["read", "readWrite", "dbAdmin", "userAdmin", "clusterAdmin"].sort();
 		}
 		const names: Record<string, true> = {};
-		for (const r of roles) {
+		for (const r of roles as RoleDoc[]) {
 			if (r?.role) {
 				names[r.role] = true;
 			}
@@ -295,8 +300,9 @@
 
 	// Database names for the role-target dropdown.
 	const databaseNames = $derived.by(() => {
-		const dbs = resolvedDatabases;
-		if (!dbs || dbs instanceof Error || !Array.isArray(dbs)) {
+		const res = resolvedDatabases;
+		const dbs = res?.data;
+		if (!res || res.error || !Array.isArray(dbs)) {
 			return ["admin"];
 		}
 		const names = (dbs as unknown[]).filter((d): d is string => typeof d === "string");
@@ -344,15 +350,15 @@
 	}
 </script>
 
-{#await usersData}
+{#await usersResult}
 	<Panel title="Users">
 		<div class="loading">Loading users...</div>
 	</Panel>
-{:then result}
-	{#if result instanceof Error}
+{:then res}
+	{#if res.error}
 		<Panel title="Users">
 			<div class="p-4">
-				<p class="error">Error loading users: {result.message}</p>
+				<p class="error">Error loading users: {res.error}</p>
 				<p class="text-sm mt-2" style="color: var(--text-darker);">
 					User management requires the connected MongoDB user to have the <code>userAdmin</code> or
 					<code>userAdminAnyDatabase</code> role (or equivalent) on the <code>admin</code> database.
@@ -381,7 +387,7 @@
 			{/if}
 		</div>
 
-		{#if result.length === 0}
+		{#if res.data.length === 0}
 			<Panel title="Users">
 				<div class="text-center p-4" style="color: var(--text-darker)">No users found</div>
 			</Panel>
@@ -401,7 +407,7 @@
 							</tr>
 						</thead>
 						<tbody>
-							{#each result as user (user.user)}
+							{#each res.data as user (user.user)}
 								{@const isLoading = operatingUsers.has(user.user)}
 								<tr class="group" class:opacity-50={isLoading}>
 									<td class="name-cell">
@@ -458,23 +464,23 @@
 									</td>
 									{#if !readOnly}
 										<td>
-											<div class="flex gap-2 hidden group-hover:flex -my-2">
+											<div class="flex gap-1.5 items-center justify-end whitespace-nowrap hidden group-hover:flex">
 												<button
-													class="btn btn-outline-primary btn-sm"
+													class="btn btn-outline-primary px-2 py-1 text-xs whitespace-nowrap"
 													onclick={() => openRolesModal(user)}
 													disabled={isLoading}
 												>
 													Edit Roles
 												</button>
 												<button
-													class="btn btn-outline-light btn-sm"
+													class="btn btn-outline-light px-2 py-1 text-xs whitespace-nowrap"
 													onclick={() => openPasswordModal(user.user)}
 													disabled={isLoading}
 												>
 													Password
 												</button>
 												<button
-													class="btn btn-outline-danger btn-sm"
+													class="btn btn-outline-danger px-2 py-1 text-xs whitespace-nowrap"
 													onclick={() => openDropModal(user.user)}
 													disabled={isLoading}
 												>
@@ -491,12 +497,8 @@
 			</Panel>
 		{/if}
 	{/if}
-{:catch err}
-	<Panel title="Users">
-		<div class="p-4">
-			<p class="error">Error loading users: {err}</p>
-		</div>
-	</Panel>
+{:catch}
+	<!-- promises resolve with {data,error} and never reject; placeholder -->
 {/await}
 
 <!-- Create user modal -->

--- a/src/routes/servers/[server]/users/+page.svelte
+++ b/src/routes/servers/[server]/users/+page.svelte
@@ -3,6 +3,7 @@
 		createUser as createUserCommand,
 		dropUser as dropUserCommand,
 		grantRolesToUser as grantRolesToUserCommand,
+		listUsers,
 		revokeRolesFromUser as revokeRolesFromUserCommand,
 		updateUserPassword as updateUserPasswordCommand,
 	} from "$api/servers.remote";
@@ -206,6 +207,25 @@
 		inheritedPrivileges = null;
 	}
 
+	// Re-fetch the open modal user's resolved privileges after a role change so
+	// the "Resolved Privileges" panel reflects the new effective permissions.
+	async function refreshModalPrivileges() {
+		if (!rolesUser) {
+			return;
+		}
+		try {
+			const res = await listUsers({ server: data.server });
+			const match = (res.data ?? []).find(
+				(u: { user: string; db: string }) => u.user === rolesUser && u.db === rolesUserDb,
+			);
+			if (match?.inheritedPrivileges !== undefined) {
+				inheritedPrivileges = match.inheritedPrivileges;
+			}
+		} catch {
+			// non-fatal: the modal just keeps its previous privileges snapshot
+		}
+	}
+
 	async function removeRole(role: { role: string; db: string }) {
 		if (!rolesUser || updatingRoles) {
 			return;
@@ -225,6 +245,7 @@
 			notificationStore.notifySuccess(`Revoked ${role.role}@${role.db} from ${rolesUser}`);
 			resolvedUsers = null;
 			await invalidate("app:users");
+			await refreshModalPrivileges();
 		} catch (error) {
 			notificationStore.notifyError(error, "Failed to revoke role");
 		} finally {
@@ -257,6 +278,7 @@
 			notificationStore.notifySuccess(`Granted ${role.role}@${role.db} to ${rolesUser}`);
 			resolvedUsers = null;
 			await invalidate("app:users");
+			await refreshModalPrivileges();
 		} catch (error) {
 			notificationStore.notifyError(error, "Failed to grant role");
 		} finally {


### PR DESCRIPTION
<img width="1523" height="402" alt="image" src="https://github.com/user-attachments/assets/960261d0-f987-45ea-aebb-a845d6541902" />
<img width="1576" height="325" alt="image" src="https://github.com/user-attachments/assets/75287fe6-ef5a-41f0-8bdd-8e0187b75de0" />
<img width="1525" height="475" alt="image" src="https://github.com/user-attachments/assets/173ab6b1-db0f-4594-a214-b85e0e76301b" />

cc @arekborucki 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces privileged operations (create/drop users, role grants, password resets) against live clusters; mistakes or weak deployment controls can directly affect MongoDB access.
> 
> **Overview**
> Adds **cluster-wide MongoDB user administration** from the server UI: list users (with per-user resolved privileges), roles, and databases, plus create/drop users, grant/revoke roles, and reset passwords.
> 
> New remote endpoints in `servers.remote.ts` wrap `usersInfo` / `rolesInfo` and mutating admin commands on the correct auth `db`, with **`checkReadOnly()`** on writes. A **Users** link on the databases panel routes to `/servers/[server]/users`, backed by a streamed `+page.server.ts` load and a large `+page.svelte` (tables, privilege breakdown, modals, `invalidate("app:users")` after changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b65566d29f7a0773f0ba476c90c75f185a0de7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->